### PR TITLE
fix: restore min and peak refresh rate correctly after game session

### DIFF
--- a/src/core/display.rs
+++ b/src/core/display.rs
@@ -20,16 +20,40 @@ pub async fn set_refresh_rate(hz: u32) -> Result<()> {
     Ok(())
 }
 
-pub async fn get_refresh_rate() -> Result<u32> {
+async fn read_rate_setting(name: &str) -> Result<u32> {
     let output = Command::new("settings")
-        .args(["get", "system", "min_refresh_rate"])
+        .args(["get", "system", name])
         .output()
         .await?;
 
+    // Android stores these as floats (e.g. "60.0"), so parse via f64 then round.
     Ok(String::from_utf8_lossy(&output.stdout)
         .trim()
-        .parse()
+        .parse::<f64>()
+        .map(|f| f.round() as u32)
         .unwrap_or(0))
+}
+
+pub async fn get_display_rates() -> Result<(u32, u32)> {
+    let min = read_rate_setting("min_refresh_rate").await?;
+    let peak = read_rate_setting("peak_refresh_rate").await?;
+    Ok((min, peak))
+}
+
+pub async fn restore_display_rates(min: u32, peak: u32) -> Result<()> {
+    debug!(target: "auriya::display", "Restoring refresh rates min={}Hz peak={}Hz", min, peak);
+
+    let _ = Command::new("settings")
+        .args(["put", "system", "min_refresh_rate", &min.to_string()])
+        .status()
+        .await?;
+
+    let _ = Command::new("settings")
+        .args(["put", "system", "peak_refresh_rate", &peak.to_string()])
+        .status()
+        .await?;
+
+    Ok(())
 }
 
 pub async fn reset_refresh_rate() -> Result<()> {

--- a/src/daemon/run.rs
+++ b/src/daemon/run.rs
@@ -88,7 +88,7 @@ pub struct Daemon {
     pub(crate) balance_governor: String,
     pub(crate) default_mode: ProfileMode,
     pub(crate) supported_modes: Vec<crate::core::display::DisplayMode>,
-    pub(crate) refresh_rate_map: std::collections::HashMap<String, u32>,
+    pub(crate) refresh_rate_map: std::collections::HashMap<String, (u32, u32)>,
     pub(crate) cached_whitelist: HashSet<String>,
 }
 

--- a/src/daemon/tick.rs
+++ b/src/daemon/tick.rs
@@ -168,12 +168,12 @@ impl Daemon {
                     bump_log(&mut self.last);
                 }
                 if self.last.pkg.as_deref() != Some(pkg)
-                    && let Some(last_pkg) = &self.last.pkg
-                    && let Some(original_rate) = self.refresh_rate_map.remove(last_pkg)
+                    && let Some(last_pkg) = &self.last.pkg.clone()
+                    && let Some((min, peak)) = self.refresh_rate_map.remove(last_pkg)
                 {
-                    debug!(target: "auriya::display", "Restoring refresh rate for {}: {}Hz", last_pkg, original_rate);
-                    if let Err(e) = crate::core::display::set_refresh_rate(original_rate).await {
-                        error!(target: "auriya::display", ?e, "Failed to restore refresh rate");
+                    debug!(target: "auriya::display", "Restoring rates for {}: min={}Hz peak={}Hz", last_pkg, min, peak);
+                    if let Err(e) = crate::core::display::restore_display_rates(min, peak).await {
+                        error!(target: "auriya::display", ?e, "Failed to restore refresh rates");
                     }
                 }
 
@@ -215,13 +215,13 @@ impl Daemon {
 
                 if let Some(rr) = game_cfg.and_then(|c| c.refresh_rate) {
                     if !self.refresh_rate_map.contains_key(pkg) {
-                        match crate::core::display::get_refresh_rate().await {
-                            Ok(current) => {
-                                self.refresh_rate_map.insert(pkg.to_string(), current);
-                                debug!(target: "auriya::display", "Saved current rate for {}: {}Hz", pkg, current);
+                        match crate::core::display::get_display_rates().await {
+                            Ok((min, peak)) => {
+                                self.refresh_rate_map.insert(pkg.to_string(), (min, peak));
+                                debug!(target: "auriya::display", "Saved rates for {}: min={}Hz peak={}Hz", pkg, min, peak);
                             }
                             Err(e) => {
-                                warn!(target: "auriya::display", "Failed to read current refresh rate: {}", e)
+                                warn!(target: "auriya::display", "Failed to read current refresh rates: {}", e)
                             }
                         }
                     }
@@ -254,11 +254,11 @@ impl Daemon {
         use crate::core::profile;
 
         if self.last.pkg.as_deref() != Some(pkg)
-            && let Some(last_pkg) = &self.last.pkg
-            && let Some(original_rate) = self.refresh_rate_map.remove(last_pkg)
+            && let Some(last_pkg) = &self.last.pkg.clone()
+            && let Some((min, peak)) = self.refresh_rate_map.remove(last_pkg)
         {
-            debug!(target: "auriya::display", "Restoring refresh rate for {}: {}Hz ({})", last_pkg, original_rate, reason);
-            let _ = crate::core::display::set_refresh_rate(original_rate).await;
+            debug!(target: "auriya::display", "Restoring rates for {}: min={}Hz peak={}Hz ({})", last_pkg, min, peak, reason);
+            let _ = crate::core::display::restore_display_rates(min, peak).await;
         }
 
         if self.last.profile_mode != Some(self.default_mode) {
@@ -308,9 +308,15 @@ impl Daemon {
                 debug!(target: "auriya::daemon", "No foreground app detected");
                 bump_log(&mut self.last);
             }
-            self.last.pkg = None;
+            if let Some(last_pkg) = self.last.pkg.take() {
+                if let Some((min, peak)) = self.refresh_rate_map.remove(&last_pkg) {
+                    debug!(target: "auriya::display", "Restoring rates for {} (no foreground): min={}Hz peak={}Hz", last_pkg, min, peak);
+                    let _ = crate::core::display::restore_display_rates(min, peak).await;
+                } else {
+                    let _ = crate::core::display::reset_refresh_rate().await;
+                }
+            }
             self.last.pid = None;
-            let _ = crate::core::display::reset_refresh_rate().await;
         }
     }
 


### PR DESCRIPTION
## Problem

After closing a game with a custom refresh rate configured, the system refresh rate was not restored to the original values. Instead both `min_refresh_rate` and `peak_refresh_rate` were set to `0`.

Tested on OnePlus Nord 4 (crDroid) with min=60Hz / peak=90Hz system settings and 120Hz configured for Brawl Stars.

## Root cause

Three compounding bugs:

1. `get_refresh_rate()` parsed the setting value as `u32`. Android returns "60.0" (a float string), which fails `u32` parsing and silently falls back to `unwrap_or(0)`. The saved snapshot was always `0`.

2. Only `min_refresh_rate` was snapshotted. Users with asymmetric settings (e.g. min=60 / peak=90) would lose their peak setting even if parsing were fixed.

3. `handle_no_foreground()` called `reset_refresh_rate()` (sets both to 0) without consulting the snapshot map, orphaning the saved rates during app-switch transitions.

## Fix

- Parse refresh rate settings as `f64` then round to `u32`
- Snapshot both `min_refresh_rate` and `peak_refresh_rate` as a pair
- Restore both values independently on game exit
- `handle_no_foreground` now restores from the map first, falling back to reset only when no snapshot exists

Im not a RUST developer, so code was written by Claude Code. Tested myself and can verify that module works with no issues related to changed functionality